### PR TITLE
Remove 'plab.site' from community.lst

### DIFF
--- a/community.lst
+++ b/community.lst
@@ -337,7 +337,6 @@ piccy.info
 pixiv.net
 production-openaicom-storage.azureedge.net
 proxyscrape.com
-plab.site
 platform.twitter.com
 polit.ru
 prnt.sc


### PR DESCRIPTION
Removed 'plab.site' from the community list. #219
