### PR TITLE
Enhance build workflow with GitHub CLI and version updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
-name: Build domains_all, ipsum, XRay and Sing-Box Files
+name: Beta - Build domains_all, ipsum, XRay and Sing-Box Files
+
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch: # Allows manual trigger of the workflow
@@ -17,6 +21,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.12'
+
+    - name: Install GitHub CLI
+      run: sudo apt-get install -y gh
+
+    - name: Authenticate GitHub CLI
+      run: gh auth setup-git
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: |
@@ -68,7 +80,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: '1.24'
 
     - name: Prepare Xray-GeoIP
       run: |
@@ -118,6 +130,41 @@ jobs:
 
         # Run the generate-geoip-geosite script
         ./generate-geoip-geosite -i ./refilter -o ./refilter
+
+    - name: Stage root outputs for PR
+      run: |
+        CURRENT_DATE=$(date +%d-%m-%Y)
+        BRANCH="update-$CURRENT_DATE"
+
+        cp $GITHUB_WORKSPACE/sum/output/domains_all.lst $GITHUB_WORKSPACE/domains_all.lst
+        cp $GITHUB_WORKSPACE/sum/output/ipsum.lst $GITHUB_WORKSPACE/ipsum.lst
+        cp $GITHUB_WORKSPACE/sum/input/ooni_domains.lst $GITHUB_WORKSPACE/ooni_domains.lst
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        git checkout -b "$BRANCH"
+        git add domains_all.lst ipsum.lst ooni_domains.lst
+
+        if git diff --cached --quiet; then
+          echo "No changes to commit."
+          exit 0
+        fi
+
+        git commit -m "$CURRENT_DATE Update"
+        git push -u origin "$BRANCH"
+
+    - name: Create PR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        CURRENT_DATE=$(date +%d-%m-%Y)
+        gh pr create \
+          --base beta \
+          --head "update-$CURRENT_DATE" \
+          --title "$CURRENT_DATE Update" \
+          --body "$CURRENT_DATE Automated update of domains_all.lst, ipsum.lst, and ooni_domains.lst."
+
       
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4
@@ -135,14 +182,6 @@ jobs:
           src/sing-box-files/refilter/ruleset-ip-refilter_ipsum.srs
           src/sing-box-files/refilter/ruleset-ip-refilter_ipsum.json
           
-    - name: Install GitHub CLI
-      run: sudo apt-get install -y gh
-
-    - name: Authenticate GitHub CLI
-      run: gh auth setup-git
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Set Release Name and Tag
       run: |
         # Define the date
@@ -150,8 +189,8 @@ jobs:
         CURRENT_TAG=$(date +%d%m%Y)
 
         # Format the release name and tag
-        RELEASE_NAME="Release $CURRENT_DATE"
-        TAG_NAME="$CURRENT_TAG"
+        RELEASE_NAME="Release $CURRENT_DATE (beta)"
+        TAG_NAME="${CURRENT_TAG}-beta"
 
         # Export as environment variables
         echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_ENV
@@ -184,5 +223,3 @@ jobs:
         gh release view "$TAG_NAME"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-


### PR DESCRIPTION
Updated the build workflow to include GitHub CLI authentication and changed the Go version to 1.24. Modified release naming to include '(beta)' and adjusted the branch naming convention for updates.