### PR TITLE
Add services.gearboxsoftware.com to community list

### DIFF
--- a/community.lst
+++ b/community.lst
@@ -434,6 +434,7 @@ support.cambiumnetworks.com
 support.huawei.com
 support.ruckuswireless.com
 shift.services.gearbox.com
+services.gearboxsoftware.com
 swagger.io
 sysdig.com
 terraform.io


### PR DESCRIPTION
https://github.com/1andrevich/Re-filter-lists/issues/294#issuecomment-3816575887

> domain:services.gearboxsoftware.com тоже нужен (CNAME для maw, в частности проскакивали maw.data.services или схожие по смыслу без приписки shift.)
