### PR TITLE
Add Marathon and partial Destiny 2 to community.lst

### DIFF
--- a/community.lst
+++ b/community.lst
@@ -428,6 +428,8 @@ signal.org
 signalusers.org
 signon.goliath.prod.deadorbit.net
 signon.goliath.prod.gravityshavings.net
+signon2.deadorbit.net
+signon2.gravityshavings.net
 soundcloud.com
 sndcdn.com
 spotify.com


### PR DESCRIPTION
Для Destiny 2 ещё нужен домен steamserver.net, но, думаю, нецелесообразно добавлять его ради одной игры, т.к. он используется многими другими играми. Для тех, кому это нужно, можно создать отдельное правило с этим доменом, включать его на время игры и выключать после.