### PR TITLE
Add Nintendo/Supercell/diff related domains

### DIFF
--- a/community.lst
+++ b/community.lst
@@ -278,6 +278,7 @@ grammarly.com
 grazie.ai
 g2a.com
 gtagarage.com
+geode-sdk.org
 habr.com
 rezka.ag
 hdrezka.ag


### PR DESCRIPTION
Based on #214 , self Wireshark traffic checking, and user responses
Including Amiibo and Wii related domains

Excluded:
CN Unicode(and English) related domains like:
legendofzelda.cn
legendofzelda.com.cn
xn--mts47c3w9b1qr.cn
xn--mts47c3w9b1qr.net
https://thelegendarystarfy.com - DNS NOT FOUND
kirbysepicyarn.com - BAD CERTIFICATE(NINTENDO)
kirbysuperstarultra.com - REDIRECT TO POKEMON
kyurem.com - REDIRECT TO NINTENDO
hackyourconsole.com - REDIRECT TO NINTENDO (Also nintendo sued that domain holders so idk i dont want test my luck)
giratina.com - ERR_CONNECTION_REFUSED so maybe it redirect to pokemon related site
gloryofheracles.com - REDIRECT TO NOT POKEMON/NINTENDO related
fireemblemawakening.com - BAD CERTIFICATE(NINTENDO)
flipnotestudio.com - DNS NOT FOUND

UPD: Also added Supercell company related domains, to avoid geo restrictions on Supercell related projects
Added root domains, because each game mainly accesses 1/2 levels of subdomains (mostly 1) to request game services

geode-sdk.org - bring mod manager to geometry dash game, but not work because use a cloudflare solutions, and some structures also not loading on game lists before adding
