### PR TITLE
Add 'notebooklm.google.com' to community.lst

### DIFF
--- a/community.lst
+++ b/community.lst
@@ -368,6 +368,7 @@ notion.site
 notion.so
 notepad-plus-plus.org
 notebooklm.google
+notebooklm.google.com
 ntc.party
 nyaa.si
 nyaa.tracker.wf


### PR DESCRIPTION
NotebookLM используем notebooklm.google только для лендинга, где при нажатии "Try NotebookLM" происходит редирект на notebooklm.google.com, где лежит основной функционал. Так как notebooklm.google.com нет в списке, пользователя возвращает обратно на лендинг. Из-за этого NotebookLM невозможно использовать

В v2fly/domain-list-community тоже используют оба домена сразу - https://github.com/v2fly/domain-list-community/blob/master/data/google-deepmind